### PR TITLE
dataDirフラグのバリデーションのメッセージ修正

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ func validateFlags() {
 	}
 
 	if *dataDir == "" {
-		log.Fatalf("flag --raft_data_dir is required")
+		log.Fatalf("flag --data_dir is required")
 	}
 }
 


### PR DESCRIPTION
```go
dataDir      = flag.String("data_dir", "", "Raft data dir")
```
と定義されているdataDirフラグのバリデーション時に出力されるメッセージの修正。